### PR TITLE
Svelte reactive-statementを使うようにする

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -20,9 +20,9 @@
     counterList = counterList.filter((counterList) => counterList.id != event.detail.id);
   }
 
-  function sumOfCounter(CounterList: TCounter[]): number {
-    return CounterList.map((counter) => counter.count).reduce((prev, curr) => prev + curr, 0);
-  }
+  $: sumOfCounter = counterList.reduce((sum, curr) => sum + curr.count, 0);
+
+  $: titleList = counterList.map((counter) => counter.title).join();
 </script>
 
 <Styles />
@@ -36,12 +36,9 @@
 
   <Button block color="info" on:click={add}>new counter</Button>
   <p>
-    title list:
-    {#each counterList as counter}
-      {counter.title},
-    {/each}
+    title list: {titleList}
   </p>
-  <p>sum of count: {sumOfCounter(counterList)}</p>
+  <p>sum of count: {sumOfCounter}</p>
 </main>
 
 <style>


### PR DESCRIPTION
# 対応するissue
closes #3 closes #4 

# 修正点
- 以下のロジックでreactive-statementを使うようにする
 - 複数カウンターの合計値を取得する
 - カウンター名のリストを取得する
- カウンター名リストの末尾にカンマが残らないようにする
![image](https://user-images.githubusercontent.com/61864556/164432855-444b45f2-4a67-419b-a7c2-2e5a4b485eb6.png)
